### PR TITLE
make default sonar system user configurable. Default to sonar

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 workspace: /root
 
+# Change Sonar default user
+sonar_service_account: sonar
+
 # Default to the latest LTS release.
 sonar_download_url: https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-4.5.6.zip
 sonar_version_directory: sonarqube-4.5.6

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,31 @@
     - /usr/bin/sonar
     - /etc/init.d/sonar
 
+- name: ensure sonar RUN_AS_USER is set correctly
+  lineinfile:
+    dest: /usr/local/sonar/bin/linux-x86-64/sonar.sh
+    regexp: ^#RUN_AS_USER
+    line: "RUN_AS_USER=sonar"
+
+- name: create sonar group as defined by sonar_service_account
+  group:
+    name: "{{ sonar_service_account }}"
+    state: present
+
+- name: create sonar user as defined by sonar_service_account
+  user:
+    name: "{{ sonar_service_account }}"
+    group: "{{ sonar_service_account }}"
+    createhome: no
+    home: /usr/local/sonar
+    
+- name: ensure correct ownership of sonar folders
+  file:
+    path: /usr/local/sonar 
+    owner: "{{ sonar_service_account }}"
+    group: "{{ sonar_service_account }}"
+    recurse: yes
+
 - name: Ensure Sonar is running and set to start on boot.
   service: name=sonar state=started enabled=yes
 


### PR DESCRIPTION
Thank you for making this awesome role. I felt like it would be better not to run Sonar as root by default, hence this PR. I've tested this inside your geerlingguy/centos7 box.
Let me know if this is acceptable  or if you have any feedback.

Regards,

Barry
