### PR TITLE
Added option to avoid local mysql instalation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ sonar_version_directory: "sonarqube-{{ sonar_version }}"
 sonar_web_context: ''
 
 # MySQL database connection details.
+sonar_mysql_install: yes
 sonar_mysql_username: sonar
 sonar_mysql_password: sonar
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 dependencies:
   - geerlingguy.java
-  - geerlingguy.mysql
+  - { role: 'geerlingguy.mysql', when: sonar_mysql_install == "yes" }
 
 galaxy_info:
   author: geerlingguy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   mysql_db:
     name: "{{ sonar_mysql_database }}"
     state: present
+  when: sonar_mysql_install == "yes"
 
 - name: Create a sonar user.
   mysql_user:
@@ -11,6 +12,7 @@
     priv: "{{ sonar_mysql_database }}.*:ALL"
     password: "{{ sonar_mysql_password }}"
   with_items: "{{ sonar_mysql_allowed_hosts }}"
+  when: sonar_mysql_install == "yes"
 
 - name: Download Sonar.
   get_url:


### PR DESCRIPTION
Tested 2 times, it works, you only need to have a already set up database server (with sonar database/user/pass) and set on your playbook the following variables:
        sonar_mysql_install: no
        sonar_mysql_user: <sonardatabaseuser>
        sonar_mysql_password: <sonardatabasepassword>
        sonar_mysql_host: <databaseserver>

