### PR TITLE
Added support for Sonar 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.retry
 tests/test.sh
+
+*.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ The value of `sonar.web.context`. Setting this to something like `/sonar` allows
 
 JDBC settings for a connection to a MySQL database. Defaults presume the database resides on localhost and is only accessible on the SonarQube server itself.
 
+The sonar process user and group can be set with the following variables.
+
+    sonar_process_user: sonar
+    sonar_process_group: sonar
+
 ## Dependencies
 
   - geerlingguy.java

--- a/README.md
+++ b/README.md
@@ -66,6 +66,47 @@ The sonar process user and group can be set with the following variables.
 
 Using the defaults, you can view the SonarQube home at `http://localhost:9000/` (default System administrator credentials are `admin`/`admin`).
 
+### Running on Debian(-like) systems with SonarQube 5.6+
+
+    - name: Override variabeles for MySQL (Debian)
+      set_fact:
+        mysql_packages:
+          - mysql-server-5.6
+      when: ansible_os_family == "Debian"
+      
+### Running on RedHat based systems with SonarQube 5.6
+
+    pre_tasks:
+    
+    - name: setup other repo for mysql
+      copy:
+        content: |
+          [mysql56-community]
+          name=MySQL 5.6 Community Server
+          baseurl=http://repo.mysql.com/yum/mysql-5.6-community/el/7/$basearch/
+          enabled=1
+          gpgcheck=1
+          gpgkey=http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8C718D3B5072E1F5
+        dest: /etc/yum.repos.d/mysql56-community.repo
+      when: "ansible_os_family == 'RedHat'"
+
+    - name: setup new version of mariadb
+      file:
+        path: /var/run/mariadb/
+        state: directory
+        mode: 0777
+      when: "ansible_os_family == 'RedHat'"
+
+    - name: Define mysql_log_error.
+      set_fact:
+        mysql_log_error: /var/log/mariadb.log
+        mysql_daemon: mysqld
+        mysql_packages:
+          - mysql
+          - mysql-community-server
+          - mysql-community-libs
+      when: "ansible_os_family == 'RedHat'"
+
 ## License
 
 MIT / BSD

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,8 @@ workspace: /root
 sonar_download_validate_certs: yes
 
 # Default to the latest LTS release.
-sonar_version: 4.5.6
-sonar_download_url: "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-{{ sonar_version }}.zip"
+sonar_version: 6.6
+sonar_download_url: "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-{{sonar_version}}.zip"
 sonar_version_directory: "sonarqube-{{ sonar_version }}"
 
 sonar_web_context: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,8 @@ sonar_mysql_allowed_hosts:
   - "127.0.0.1"
   - "::1"
   - "localhost"
+
+
+
+sonar_process_user: sonar
+sonar_process_group: "{{ sonar_process_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Set correct Java version
+  alternatives:
+    name: java
+    path: /usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/bin/java
+  when: ansible_os_family == 'Debian' and ansible_distribution_version == "14.04"
+
 - name: Create a database for Sonar.
   mysql_db:
     name: "{{ sonar_mysql_database }}"
@@ -14,6 +20,7 @@
     name: "{{sonar_process_user}}"
     group: "{{sonar_process_group}}"
     home: /usr/local/sonar
+    createhome: no
 
 - name: Create a sonar mysql user.
   mysql_user:
@@ -48,6 +55,7 @@
     group: "{{sonar_process_group}}"
     mode: 0775
     recurse: yes
+  changed_when: false
 
 - include: configure.yml
 
@@ -63,6 +71,13 @@
     src: /usr/local/sonar/bin/linux-x86-64/sonar.sh
     dest: /etc/init.d/sonar
     state: link
+  when: "ansible_service_mgr != 'systemd'"
+
+- name: Find and replace runasuser in service  management
+  lineinfile:
+    path: /etc/init.d/sonar
+    regexp: '^#?RUN_AS_USER='
+    line: "RUN_AS_USER={{sonar_process_user}}"
   when: "ansible_service_mgr != 'systemd'"
 
 - name: Copy SonarQube systemd unit file into place (for systemd systems).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,18 @@
     name: "{{ sonar_mysql_database }}"
     state: present
 
-- name: Create a sonar user.
+- name: Create sonar group
+  group:
+    name: "{{sonar_process_group}}"
+    state: present
+
+- name: Create sonar user
+  user:
+    name: "{{sonar_process_user}}"
+    group: "{{sonar_process_group}}"
+    home: /usr/local/sonar
+
+- name: Create a sonar mysql user.
   mysql_user:
     name: "{{ sonar_mysql_username }}"
     host: "{{ item }}"
@@ -29,6 +40,14 @@
   shell: >
     mv /usr/local/{{ sonar_version_directory }} /usr/local/sonar
     creates=/usr/local/sonar/COPYING
+
+- name: Change Owner of sonar
+  file:
+    dest: /usr/local/sonar
+    owner: "{{sonar_process_user}}"
+    group: "{{sonar_process_group}}"
+    mode: 0775
+    recurse: yes
 
 - include: configure.yml
 

--- a/templates/sonar.unit.j2
+++ b/templates/sonar.unit.j2
@@ -9,6 +9,7 @@ ExecStop=/usr/bin/sonar stop
 ExecReload=/usr/bin/sonar restart
 PIDFile=/usr/local/sonar/bin/linux-x86-64/./SonarQube.pid
 Type=simple
+User={{sonar_process_user}}
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/test-latest.yml
+++ b/tests/test-latest.yml
@@ -37,6 +37,12 @@
         mysql_socket: /var/lib/mysql/mysql.sock
       when: ansible_os_family == "RedHat"
 
+    - name: Override varaibles for MySQL (Debian)
+      set_fact:
+        mysql_packages:
+          - mysql-server-5.6
+      when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
+
   roles:
     - role: geerlingguy.java
       when: "ansible_os_family == 'RedHat'"
@@ -48,5 +54,6 @@
       java_packages:
         - openjdk-8-jdk
 
-    - geerlingguy.mysql
+    - role: geerlingguy.mysql
+
     - role_under_test

--- a/tests/test-latest.yml
+++ b/tests/test-latest.yml
@@ -3,7 +3,7 @@
 
   vars:
     # Latest version of SonarQube, from http://www.sonarqube.org/downloads/
-    sonar_version: 5.6.1
+    sonar_version: 6.6
 
   pre_tasks:
     - name: Update apt cache.
@@ -21,27 +21,40 @@
       apt_repository: repo='ppa:openjdk-r/ppa'
       when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
 
-    - name: Install the MySQL repo (RedHat).
-      yum:
-        name: http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm
-        state: present
-      when: ansible_os_family == "RedHat"
+    - name: setup other repo for mysql
+      copy:
+        content: |
+          [mysql56-community]
+          name=MySQL 5.6 Community Server
+          baseurl=http://repo.mysql.com/yum/mysql-5.6-community/el/7/$basearch/
+          enabled=1
+          gpgcheck=1
+          gpgkey=http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8C718D3B5072E1F5
+        dest: /etc/yum.repos.d/mysql56-community.repo
+      when: "ansible_os_family == 'RedHat'"
 
-    - name: Override variables for MySQL (RedHat).
+    - name: setup new version of mariadb
+      file:
+        path: /var/run/mariadb/
+        state: directory
+        mode: 0777
+      when: "ansible_os_family == 'RedHat'"
+
+    - name: Define mysql_log_error.
       set_fact:
+        mysql_log_error: /var/log/mariadb.log
         mysql_daemon: mysqld
-        mysql_packages: ['mysql-server']
-        mysql_log_error: /var/log/mysqld.err
-        mysql_syslog_tag: mysqld
-        mysql_pid_file: /var/run/mysqld/mysqld.pid
-        mysql_socket: /var/lib/mysql/mysql.sock
-      when: ansible_os_family == "RedHat"
+        mysql_packages:
+          - mysql
+          - mysql-community-server
+          - mysql-community-libs
+      when: "ansible_os_family == 'RedHat'"
 
-    - name: Override varaibles for MySQL (Debian)
+    - name: Override variabeles for MySQL (Debian)
       set_fact:
         mysql_packages:
           - mysql-server-5.6
-      when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
+      when: ansible_os_family == "Debian"
 
   roles:
     - role: geerlingguy.java

--- a/tests/test-latest.yml
+++ b/tests/test-latest.yml
@@ -54,7 +54,7 @@
       set_fact:
         mysql_packages:
           - mysql-server-5.6
-      when: ansible_os_family == "Debian"
+      when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
 
   roles:
     - role: geerlingguy.java

--- a/tests/test-lts.yml
+++ b/tests/test-lts.yml
@@ -7,13 +7,31 @@
       when: ansible_os_family == 'Debian'
       changed_when: false
 
+    - name: installing repo for Java 8 in Ubuntu
+      apt_repository: repo='ppa:openjdk-r/ppa'
+      when: ansible_os_family == 'Debian'
+
     - name: Install dependencies.
       package: "name={{ item }} state=present"
       with_items:
         - curl
         - unzip
 
+    - name: Override varaibles for MySQL (Debian)
+      set_fact:
+        mysql_packages:
+          - mysql-server-5.6
+      when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
+
   roles:
-    - geerlingguy.java
+    - role: geerlingguy.java
+      when: "ansible_os_family == 'RedHat'"
+      java_packages:
+        - java-1.8.0-openjdk
+
+    - role: geerlingguy.java
+      when: "ansible_os_family == 'Debian'"
+      java_packages:
+        - openjdk-8-jdk
     - geerlingguy.mysql
     - role_under_test

--- a/tests/test-lts.yml
+++ b/tests/test-lts.yml
@@ -51,7 +51,7 @@
       set_fact:
         mysql_packages:
           - mysql-server-5.6
-      when: ansible_os_family == "Debian"
+      when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
 
   roles:
     - role: geerlingguy.java

--- a/tests/test-lts.yml
+++ b/tests/test-lts.yml
@@ -2,6 +2,36 @@
 - hosts: all
 
   pre_tasks:
+
+    - name: setup other repo for mysql
+      copy:
+        content: |
+          [mysql56-community]
+          name=MySQL 5.6 Community Server
+          baseurl=http://repo.mysql.com/yum/mysql-5.6-community/el/7/$basearch/
+          enabled=1
+          gpgcheck=1
+          gpgkey=http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8C718D3B5072E1F5
+        dest: /etc/yum.repos.d/mysql56-community.repo
+      when: "ansible_os_family == 'RedHat'"
+
+    - name: setup new version of mariadb
+      file:
+        path: /var/run/mariadb/
+        state: directory
+        mode: 0777
+      when: "ansible_os_family == 'RedHat'"
+
+    - name: Define mysql_log_error.
+      set_fact:
+        mysql_log_error: /var/log/mariadb.log
+        mysql_daemon: mysqld
+        mysql_packages:
+          - mysql
+          - mysql-community-server
+          - mysql-community-libs
+      when: "ansible_os_family == 'RedHat'"
+
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
@@ -21,7 +51,7 @@
       set_fact:
         mysql_packages:
           - mysql-server-5.6
-      when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
+      when: ansible_os_family == "Debian"
 
   roles:
     - role: geerlingguy.java

--- a/tests/test-web_context.yml
+++ b/tests/test-web_context.yml
@@ -16,7 +16,21 @@
         - curl
         - unzip
 
+    - name: Override varaibles for MySQL (Debian)
+      set_fact:
+        mysql_packages:
+          - mysql-server-5.6
+      when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
+
   roles:
-    - geerlingguy.java
+    - role: geerlingguy.java
+      when: "ansible_os_family == 'RedHat'"
+      java_packages:
+        - java-1.8.0-openjdk
+
+    - role: geerlingguy.java
+      when: "ansible_os_family == 'Debian'"
+      java_packages:
+        - openjdk-8-jdk
     - geerlingguy.mysql
     - role_under_test

--- a/tests/test-web_context.yml
+++ b/tests/test-web_context.yml
@@ -22,6 +22,35 @@
           - mysql-server-5.6
       when: ansible_os_family == "Debian" and ansible_distribution_version == "14.04"
 
+    - name: setup other repo for mysql
+      copy:
+        content: |
+          [mysql56-community]
+          name=MySQL 5.6 Community Server
+          baseurl=http://repo.mysql.com/yum/mysql-5.6-community/el/7/$basearch/
+          enabled=1
+          gpgcheck=1
+          gpgkey=http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8C718D3B5072E1F5
+        dest: /etc/yum.repos.d/mysql56-community.repo
+      when: "ansible_os_family == 'RedHat'"
+
+    - name: setup new version of mariadb
+      file:
+        path: /var/run/mariadb/
+        state: directory
+        mode: 0777
+      when: "ansible_os_family == 'RedHat'"
+
+    - name: Define mysql_log_error.
+      set_fact:
+        mysql_log_error: /var/log/mariadb.log
+        mysql_daemon: mysqld
+        mysql_packages:
+          - mysql
+          - mysql-community-server
+          - mysql-community-libs
+      when: "ansible_os_family == 'RedHat'"
+
   roles:
     - role: geerlingguy.java
       when: "ansible_os_family == 'RedHat'"


### PR DESCRIPTION
It was not possible to use SonarQube 6, because the newest version of sonar uses ElasticSearch. ElasticSearch will not run under root, so added a new tasks for creating a sonar user and changed to sonar process owner.