### PR TITLE
Switch download url from bintray.com to binaries.sonarsource.com

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ sonar_download_validate_certs: true
 
 # Default to the latest LTS release.
 sonar_version: 4.5.6
-sonar_download_url: "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-{{ sonar_version }}.zip"
+sonar_download_url: "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-{{ sonar_version }}.zip"
 sonar_version_directory: "sonarqube-{{ sonar_version }}"
 
 sonar_web_context: ''


### PR DESCRIPTION
As you can see on https://www.sonarqube.org/downloads/ we switch from bintray to our own download site.